### PR TITLE
Normalize SSID on Android Pie and above

### DIFF
--- a/app/src/main/java/org/ostrya/presencepublisher/ForegroundService.java
+++ b/app/src/main/java/org/ostrya/presencepublisher/ForegroundService.java
@@ -207,7 +207,7 @@ public class ForegroundService extends Service {
             if (wifiManager == null) {
                 Log.wtf(TAG, "No wifi manager");
             } else {
-                ssid = wifiManager.getConnectionInfo().getSSID();
+                ssid = SsidUtil.normalizeSsid(wifiManager.getConnectionInfo().getSSID());
             }
         } else {
             if (connectivityManager == null) {


### PR DESCRIPTION
Should resolve the following log message:
'"MY_SSID"' does not match desired network'MY_SSID', skipping.