### PR TITLE
Inspect all networks to see if wifi is connected

### DIFF
--- a/app/src/main/java/org/ostrya/presencepublisher/ForegroundService.java
+++ b/app/src/main/java/org/ostrya/presencepublisher/ForegroundService.java
@@ -193,8 +193,13 @@ public class ForegroundService extends Service {
             return false;
         }
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-            NetworkCapabilities networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.getActiveNetwork());
-            return networkCapabilities != null && networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
+            for (Network network : connectivityManager.getAllNetworks()) {
+                NetworkCapabilities networkCapabilities = connectivityManager.getNetworkCapabilities(network);
+                if (networkCapabilities != null && networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+                    return true;
+                }
+            }
+            return false;
         } else {
             return activeNetworkInfo.getType() == ConnectivityManager.TYPE_WIFI;
         }


### PR DESCRIPTION
When connected to a VPN, ConnectivityManager.getActiveNetwork() returns the VPN's network which doesn't have the TRANSPORT_WIFI NetworkCapabilites flag set.
This causes the app to think there is no wifi connection (only "offline" pings are sent).

This solution uses WifiInfo.getNetworkId() which returns -1 if there is no active wifi network.
The alternative solution would be to iterate over all available networks to see if there is an active wifi network among them.